### PR TITLE
Mainly VW and interior checks.

### DIFF
--- a/distance.inc
+++ b/distance.inc
@@ -27,7 +27,7 @@ stock Float:GetDistanceBetweenPoints(Float:x1, Float:y1, Float:z1, Float:x2, Flo
 
 
 stock bool:IsPointInRangeOfPoint(Float:x1, Float:y1, Float:z1, Float:x2, Float:y2, Float:z2, Float:range) {
-    return GetDistanceBetweenPoints(x1, y1, z1, x2, y2, z2) <= range;
+    return VectorSize(x1 - x2, y1 - y2, z1 - z2) <= range;
 }
 
 
@@ -37,7 +37,7 @@ stock Float:GetDistanceBetweenPoints2D(Float:x1, Float:y1, Float:x2, Float:y2) {
 
 
 stock bool:IsPointInRangeOfPoint2D(Float:x1, Float:y1, Float:x2, Float:y2, Float:range) {
-    return GetDistanceBetweenPoints2D(x1, y1, x2, y2) <= range;
+    return VectorSize(x1 - x2, y1 - y2, 0.0) <= range;
 }
 
 

--- a/distance.inc
+++ b/distance.inc
@@ -157,24 +157,88 @@ stock Float:GetDistanceBetweenPlayers(playerid1, playerid2) {
 }
 
 
-stock bool:IsPlayerInRangeOfPlayer(playerid1, playerid2, Float:range) {
-    return GetDistanceBetweenPlayers(playerid1, playerid2) <= range && GetPlayerVirtualWorld(playerid1) == GetPlayerVirtualWorld(playerid2);
+stock bool:IsPlayerInRangeOfPlayer(playerid1, playerid2, Float:range, bool:ignoreVW = false, bool:ignoreInterior = false) {
+	new Float:x, Float:y, Float:z;
+
+	return IsPlayerConnected(playerid1)
+		&& GetPlayerPos(playerid2, x, y, z)
+		&& BAD_GetPlayerDistanceFromPoint(playerid, x, y, z) <= range
+		&& (ignoreVW || GetPlayerVirtualWorld(playerid1) == GetPlayerVirtualWorld(playerid2))
+		&& (ignoreInterior || GetPlayerInterior(playerid1) == GetPlayerInterior(playerid2))
+	;
 }
 
 
-stock GetClosestPlayerToPlayer(playerid, ignoredid = INVALID_PLAYER_ID) {
-    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2, vw = GetPlayerVirtualWorld(playerid);
+stock GetClosestPlayerToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false, bool:ignoreInterior = false) {
+    new Float:x, Float:y, Float:z;
 
-    foreach (new i : Player) {
-        if (playerid == i || i == ignoredid || vw != GetPlayerVirtualWorld(i)) {
-            continue;
-        }
-
-        if ((distance2 = GetDistanceBetweenPlayers(playerid, i)) < distance) {
-            distance = distance2;
-            closestid = i;
-        }
+    if (!GetPlayerPos(playerid, x, y, z)) {
+		return INVALID_PLAYER_ID;
     }
+
+    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
+	if (ignoreInterior)
+	{
+		if (ignoreVW)
+		{
+			foreach (new i : Player) {
+				if (i == ignoredid) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+		else
+		{
+			new vw = GetPlayerVirtualWorld(playerid);
+			foreach (new i : Player) {
+				if (i == ignoredid || vw != GetPlayerVirtualWorld(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+	}
+	else
+	{
+		if (ignoreVW)
+		{
+			new interior = GetPlayerInterior(playerid);
+			foreach (new i : Player) {
+				if (i == ignoredid || interior != GetPlayerInterior(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+		else
+		{
+			new vw = GetPlayerVirtualWorld(playerid);
+			new interior = GetPlayerInterior(playerid);
+			foreach (new i : Player) {
+				if (i == ignoredid || vw != GetPlayerVirtualWorld(i) || interior != GetPlayerInterior(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+	}
 
     return closestid;
 }
@@ -203,27 +267,107 @@ stock Float:GetPlayerDistanceFromVehicle(playerid, vehicleid) {
 }
 
 
-stock bool:IsPlayerInRangeOfVehicle(playerid, vehicleid, Float:range) {
-    return GetPlayerDistanceFromVehicle(playerid, vehicleid) <= range && GetPlayerVirtualWorld(playerid) == GetVehicleVirtualWorld(vehicleid);
+stock bool:IsPlayerInRangeOfVehicle(playerid, vehicleid, Float:range, bool:ignoreVW = false
+#if defined GetVehicleInterior
+	, bool:ignoreInterior = false
+#endif
+) {
+	new Float:x, Float:y, Float:z;
+
+	return IsPlayerConnected(playerid)
+		&& GetVehiclePos(vehicleid, x, y, z)
+		&& BAD_GetPlayerDistanceFromPoint(playerid, x, y, z) <= range
+		&& (ignoreVW || GetPlayerVirtualWorld(playerid) == GetVehicleVirtualWorld(vehicleid))
+#if defined GetVehicleInterior
+		&& (ignoreInterior || GetPlayerInterior(playerid) == GetVehicleInterior(vehicleid))
+#endif
+	;
 }
 
 
-stock GetClosestVehicleToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID) {
-    new Float:distance = FLOAT_INFINITY, closestid = INVALID_VEHICLE_ID, Float:distance2, vw = GetPlayerVirtualWorld(playerid);
+stock GetClosestVehicleToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false
+#if defined GetVehicleInterior
+	, bool:ignoreInterior = false
+#endif
+) {
+    new Float:x, Float:y, Float:z;
 
-    foreach (new i : Vehicle) {
-        if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
-            continue;
-        }
-
-        if ((distance2 = GetPlayerDistanceFromVehicle(playerid, i)) < distance) {
-            distance = distance2;
-            closestid = i;
-        }
+    if (!GetPlayerPos(playerid, x, y, z)) {
+		return INVALID_PLAYER_ID;
     }
+
+    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
+#if defined GetVehicleInterior
+	if (ignoreInterior)
+#endif
+	{
+		if (ignoreVW)
+		{
+			foreach (new i : Vehicle) {
+				if (i == ignoredid) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+		else
+		{
+			new vw = GetPlayerVirtualWorld(playerid);
+			foreach (new i : Vehicle) {
+				if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+	}
+#if defined GetVehicleInterior
+	else
+	{
+		if (ignoreVW)
+		{
+			new interior = GetPlayerInterior(playerid);
+			foreach (new i : Vehicle) {
+				if (i == ignoredid || interior != GetVehicleInterior(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+		else
+		{
+			new vw = GetPlayerVirtualWorld(playerid);
+			new interior = GetPlayerInterior(playerid);
+			foreach (new i : Vehicle) {
+				if (i == ignoredid || vw != GetVehicleVirtualWorld(i) || interior != GetVehicleInterior(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+	}
+#endif
 
     return closestid;
 }
+
+
 
 
 /*
@@ -247,24 +391,102 @@ stock Float:GetDistanceBetweenVehicles(vehicleid1, vehicleid2) {
 }
 
 
-stock bool:IsVehicleInRangeOfVehicle(vehicleid1, vehicleid2, Float:range) {
-    return GetDistanceBetweenVehicles(vehicleid1, vehicleid2) <= range && GetVehicleVirtualWorld(vehicleid1) == GetVehicleVirtualWorld(vehicleid2);
+stock bool:IsVehicleInRangeOfVehicle(vehicleid1, vehicleid2, Float:range, bool:ignoreVW = false
+#if defined GetVehicleInterior
+	, bool:ignoreInterior = false
+#endif
+) {
+	new Float:x, Float:y, Float:z;
+
+	return Iter_Contains(Vehicle, vehicleid1)
+		&& GetVehiclePos(vehicleid2, x, y, z)
+		&& BAD_GetVehicleDistanceFromPoint(vehicleid1, x, y, z) <= range
+		&& (ignoreVW || GetVehicleVirtualWorld(vehicleid1) == GetVehicleVirtualWorld(vehicleid2))
+#if defined GetVehicleInterior
+		&& (ignoreInterior || GetVehicleInterior(vehicleid1) == GetVehicleInterior(vehicleid2))
+#endif
+	;
 }
 
 
-stock GetClosestVehicleToVehicle(vehicleid, ignoredid = INVALID_VEHICLE_ID) {
-    new Float:distance = FLOAT_INFINITY, closestid = INVALID_VEHICLE_ID, Float:distance2, vw = GetVehicleVirtualWorld(vehicleid);
+stock GetClosestVehicleToVehicle(vehicleid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false
+#if defined GetVehicleInterior
+	, bool:ignoreInterior = false
+#endif
+) {
+    new Float:x, Float:y, Float:z;
 
-    foreach (new i : Vehicle) {
-        if (vehicleid == i || i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
-            continue;
-        }
-
-        if ((distance2 = GetDistanceBetweenVehicles(vehicleid, i)) < distance) {
-            distance = distance2;
-            closestid = i;
-        }
+    if (!GetVehiclePos(vehicleid, x, y, z)) {
+		return INVALID_PLAYER_ID;
     }
+
+    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
+#if defined GetVehicleInterior
+	if (ignoreInterior)
+#endif
+	{
+		if (ignoreVW)
+		{
+			foreach (new i : Vehicle) {
+				if (i == ignoredid) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+		else
+		{
+			new vw = GetVehicleVirtualWorld(vehicleid);
+			foreach (new i : Vehicle) {
+				if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+	}
+#if defined GetVehicleInterior
+	else
+	{
+		if (ignoreVW)
+		{
+			new interior = GetVehicleInterior(vehicleid);
+			foreach (new i : Vehicle) {
+				if (i == ignoredid || interior != GetVehicleInterior(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+		else
+		{
+			new vw = GetVehicleVirtualWorld(vehicleid);
+			new interior = GetVehicleInterior(vehicleid);
+			foreach (new i : Vehicle) {
+				if (i == ignoredid || vw != GetVehicleVirtualWorld(i) || interior != GetVehicleInterior(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+	}
+#endif
 
     return closestid;
 }
@@ -290,19 +512,85 @@ oooooo     oooo           oooo         o8o            oooo                    oo
     IsPlayerInRangeOfVehicle(%1,%0,%2)
 
 
-stock GetClosestPlayerToVehicle(vehicleid, ignoredid = INVALID_PLAYER_ID) {
-    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2, vw = GetVehicleVirtualWorld(vehicleid);
+stock GetClosestPlayerToVehicle(vehicleid, ignoredid = INVALID_PLAYER_ID, bool:ignoreVW = false
+#if defined GetVehicleInterior
+	, bool:ignoreInterior = false
+#endif
+) {
+    new Float:x, Float:y, Float:z;
 
-    foreach (new i : Player) {
-        if (i == ignoredid || vw != GetPlayerVirtualWorld(i)) {
-            continue;
-        }
-
-        if ((distance2 = GetPlayerDistanceFromVehicle(vehicleid, i)) < distance) {
-            distance = distance2;
-            closestid = i;
-        }
+    if (!GetVehiclePos(vehicleid, x, y, z)) {
+		return INVALID_PLAYER_ID;
     }
+
+    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
+#if defined GetVehicleInterior
+	if (ignoreInterior)
+#endif
+	{
+		if (ignoreVW)
+		{
+			new vw = GetVehicleVirtualWorld(vehicleid);
+			foreach (new i : Player) {
+				if (i == ignoredid || vw != GetPlayerVirtualWorld(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+		else
+		{
+			foreach (new i : Player) {
+				if (i == ignoredid) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+	}
+#if defined GetVehicleInterior
+	else
+	{
+		if (ignoreVW)
+		{
+			new interior = GetVehicleInterior(vehicleid);
+			foreach (new i : Player) {
+				if (i == ignoredid || interior != GetPlayerInterior(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+		else
+		{
+			new vw = GetVehicleVirtualWorld(vehicleid);
+			new interior = GetVehicleInterior(vehicleid);
+			foreach (new i : Player) {
+				if (i == ignoredid || vw != GetPlayerVirtualWorld(i) || interior != GetPlayerInterior(i)) {
+					continue;
+				}
+
+				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+					distance = distance2;
+					closestid = i;
+				}
+			}
+		}
+	}
+#endif
 
     return closestid;
 }
+

--- a/distance.inc
+++ b/distance.inc
@@ -162,7 +162,7 @@ stock bool:IsPlayerInRangeOfPlayer(playerid1, playerid2, Float:range, bool:ignor
 
 	return IsPlayerConnected(playerid1)
 		&& GetPlayerPos(playerid2, x, y, z)
-		&& BAD_GetPlayerDistanceFromPoint(playerid, x, y, z) <= range
+		&& BAD_GetPlayerDistanceFromPoint(playerid1, x, y, z) <= range
 		&& (ignoreVW || GetPlayerVirtualWorld(playerid1) == GetPlayerVirtualWorld(playerid2))
 		&& (ignoreInterior || GetPlayerInterior(playerid1) == GetPlayerInterior(playerid2))
 	;
@@ -267,107 +267,111 @@ stock Float:GetPlayerDistanceFromVehicle(playerid, vehicleid) {
 }
 
 
-stock bool:IsPlayerInRangeOfVehicle(playerid, vehicleid, Float:range, bool:ignoreVW = false
 #if defined GetVehicleInterior
-	, bool:ignoreInterior = false
-#endif
-) {
-	new Float:x, Float:y, Float:z;
+	stock bool:IsPlayerInRangeOfVehicle(playerid, vehicleid, Float:range, bool:ignoreVW = false, bool:ignoreInterior = false) {
+		new Float:x, Float:y, Float:z;
 
-	return IsPlayerConnected(playerid)
-		&& GetVehiclePos(vehicleid, x, y, z)
-		&& BAD_GetPlayerDistanceFromPoint(playerid, x, y, z) <= range
-		&& (ignoreVW || GetPlayerVirtualWorld(playerid) == GetVehicleVirtualWorld(vehicleid))
-#if defined GetVehicleInterior
-		&& (ignoreInterior || GetPlayerInterior(playerid) == GetVehicleInterior(vehicleid))
-#endif
-	;
-}
-
-
-stock GetClosestVehicleToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false
-#if defined GetVehicleInterior
-	, bool:ignoreInterior = false
-#endif
-) {
-    new Float:x, Float:y, Float:z;
-
-    if (!GetPlayerPos(playerid, x, y, z)) {
-		return INVALID_PLAYER_ID;
-    }
-
-    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
-#if defined GetVehicleInterior
-	if (ignoreInterior)
-#endif
-	{
-		if (ignoreVW)
-		{
-			foreach (new i : Vehicle) {
-				if (i == ignoredid) {
-					continue;
-				}
-
-				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
-		else
-		{
-			new vw = GetPlayerVirtualWorld(playerid);
-			foreach (new i : Vehicle) {
-				if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
-					continue;
-				}
-
-				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
+		return IsPlayerConnected(playerid)
+			&& GetVehiclePos(vehicleid, x, y, z)
+			&& BAD_GetPlayerDistanceFromPoint(playerid, x, y, z) <= range
+			&& (ignoreVW || GetPlayerVirtualWorld(playerid) == GetVehicleVirtualWorld(vehicleid))
+			&& (ignoreInterior || GetPlayerInterior(playerid) == GetVehicleInterior(vehicleid))
+		;
 	}
-#if defined GetVehicleInterior
-	else
-	{
-		if (ignoreVW)
-		{
-			new interior = GetPlayerInterior(playerid);
-			foreach (new i : Vehicle) {
-				if (i == ignoredid || interior != GetVehicleInterior(i)) {
-					continue;
-				}
+#else
+	stock bool:IsPlayerInRangeOfVehicle(playerid, vehicleid, Float:range, bool:ignoreVW = false) {
+		new Float:x, Float:y, Float:z;
 
-				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
-		else
-		{
-			new vw = GetPlayerVirtualWorld(playerid);
-			new interior = GetPlayerInterior(playerid);
-			foreach (new i : Vehicle) {
-				if (i == ignoredid || vw != GetVehicleVirtualWorld(i) || interior != GetVehicleInterior(i)) {
-					continue;
-				}
-
-				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
+		return IsPlayerConnected(playerid)
+			&& GetVehiclePos(vehicleid, x, y, z)
+			&& BAD_GetPlayerDistanceFromPoint(playerid, x, y, z) <= range
+			&& (ignoreVW || GetPlayerVirtualWorld(playerid) == GetVehicleVirtualWorld(vehicleid))
+		;
 	}
 #endif
 
-    return closestid;
-}
 
+#if defined GetVehicleInterior
+	stock GetClosestVehicleToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false, bool:ignoreInterior = false) {
+#else
+	stock GetClosestVehicleToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false) {
+#endif
+		new Float:x, Float:y, Float:z;
 
+		if (!GetPlayerPos(playerid, x, y, z)) {
+			return INVALID_PLAYER_ID;
+		}
+
+		new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
+#if defined GetVehicleInterior
+		if (ignoreInterior)
+#endif
+		{
+			if (ignoreVW)
+			{
+				foreach (new i : Vehicle) {
+					if (i == ignoredid) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+			else
+			{
+				new vw = GetPlayerVirtualWorld(playerid);
+				foreach (new i : Vehicle) {
+					if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+		}
+#if defined GetVehicleInterior
+		else
+		{
+			if (ignoreVW)
+			{
+				new interior = GetPlayerInterior(playerid);
+				foreach (new i : Vehicle) {
+					if (i == ignoredid || interior != GetVehicleInterior(i)) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+			else
+			{
+				new vw = GetPlayerVirtualWorld(playerid);
+				new interior = GetPlayerInterior(playerid);
+				foreach (new i : Vehicle) {
+					if (i == ignoredid || vw != GetVehicleVirtualWorld(i) || interior != GetVehicleInterior(i)) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+		}
+#endif
+
+		return closestid;
+	}
 
 
 /*
@@ -391,105 +395,111 @@ stock Float:GetDistanceBetweenVehicles(vehicleid1, vehicleid2) {
 }
 
 
-stock bool:IsVehicleInRangeOfVehicle(vehicleid1, vehicleid2, Float:range, bool:ignoreVW = false
 #if defined GetVehicleInterior
-	, bool:ignoreInterior = false
-#endif
-) {
-	new Float:x, Float:y, Float:z;
+	stock bool:IsVehicleInRangeOfVehicle(vehicleid1, vehicleid2, Float:range, bool:ignoreVW = false, bool:ignoreInterior = false) {
+		new Float:x, Float:y, Float:z;
 
-	return Iter_Contains(Vehicle, vehicleid1)
-		&& GetVehiclePos(vehicleid2, x, y, z)
-		&& BAD_GetVehicleDistanceFromPoint(vehicleid1, x, y, z) <= range
-		&& (ignoreVW || GetVehicleVirtualWorld(vehicleid1) == GetVehicleVirtualWorld(vehicleid2))
-#if defined GetVehicleInterior
-		&& (ignoreInterior || GetVehicleInterior(vehicleid1) == GetVehicleInterior(vehicleid2))
-#endif
-	;
-}
-
-
-stock GetClosestVehicleToVehicle(vehicleid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false
-#if defined GetVehicleInterior
-	, bool:ignoreInterior = false
-#endif
-) {
-    new Float:x, Float:y, Float:z;
-
-    if (!GetVehiclePos(vehicleid, x, y, z)) {
-		return INVALID_PLAYER_ID;
-    }
-
-    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
-#if defined GetVehicleInterior
-	if (ignoreInterior)
-#endif
-	{
-		if (ignoreVW)
-		{
-			foreach (new i : Vehicle) {
-				if (i == ignoredid) {
-					continue;
-				}
-
-				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
-		else
-		{
-			new vw = GetVehicleVirtualWorld(vehicleid);
-			foreach (new i : Vehicle) {
-				if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
-					continue;
-				}
-
-				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
+		return Iter_Contains(Vehicle, vehicleid1)
+			&& GetVehiclePos(vehicleid2, x, y, z)
+			&& BAD_GetVehicleDistanceFromPoint(vehicleid1, x, y, z) <= range
+			&& (ignoreVW || GetVehicleVirtualWorld(vehicleid1) == GetVehicleVirtualWorld(vehicleid2))
+			&& (ignoreInterior || GetVehicleInterior(vehicleid1) == GetVehicleInterior(vehicleid2))
+		;
 	}
-#if defined GetVehicleInterior
-	else
-	{
-		if (ignoreVW)
-		{
-			new interior = GetVehicleInterior(vehicleid);
-			foreach (new i : Vehicle) {
-				if (i == ignoredid || interior != GetVehicleInterior(i)) {
-					continue;
-				}
+#else
+	stock bool:IsVehicleInRangeOfVehicle(vehicleid1, vehicleid2, Float:range, bool:ignoreVW = false) {
+		new Float:x, Float:y, Float:z;
 
-				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
-		else
-		{
-			new vw = GetVehicleVirtualWorld(vehicleid);
-			new interior = GetVehicleInterior(vehicleid);
-			foreach (new i : Vehicle) {
-				if (i == ignoredid || vw != GetVehicleVirtualWorld(i) || interior != GetVehicleInterior(i)) {
-					continue;
-				}
-
-				if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
+		return Iter_Contains(Vehicle, vehicleid1)
+			&& GetVehiclePos(vehicleid2, x, y, z)
+			&& BAD_GetVehicleDistanceFromPoint(vehicleid1, x, y, z) <= range
+			&& (ignoreVW || GetVehicleVirtualWorld(vehicleid1) == GetVehicleVirtualWorld(vehicleid2))
+		;
 	}
 #endif
 
-    return closestid;
-}
+
+#if defined GetVehicleInterior
+	stock GetClosestVehicleToVehicle(vehicleid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false, bool:ignoreInterior = false) {
+#else
+	stock GetClosestVehicleToVehicle(vehicleid, ignoredid = INVALID_VEHICLE_ID, bool:ignoreVW = false) {
+#endif
+		new Float:x, Float:y, Float:z;
+
+		if (!GetVehiclePos(vehicleid, x, y, z)) {
+			return INVALID_PLAYER_ID;
+		}
+
+		new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
+#if defined GetVehicleInterior
+		if (ignoreInterior)
+#endif
+		{
+			if (ignoreVW)
+			{
+				foreach (new i : Vehicle) {
+					if (i == ignoredid) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+			else
+			{
+				new vw = GetVehicleVirtualWorld(vehicleid);
+				foreach (new i : Vehicle) {
+					if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+		}
+#if defined GetVehicleInterior
+		else
+		{
+			if (ignoreVW)
+			{
+				new interior = GetVehicleInterior(vehicleid);
+				foreach (new i : Vehicle) {
+					if (i == ignoredid || interior != GetVehicleInterior(i)) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+			else
+			{
+				new vw = GetVehicleVirtualWorld(vehicleid);
+				new interior = GetVehicleInterior(vehicleid);
+				foreach (new i : Vehicle) {
+					if (i == ignoredid || vw != GetVehicleVirtualWorld(i) || interior != GetVehicleInterior(i)) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetVehicleDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+		}
+#endif
+
+		return closestid;
+	}
 
 
 /*
@@ -512,85 +522,85 @@ oooooo     oooo           oooo         o8o            oooo                    oo
     IsPlayerInRangeOfVehicle(%1,%0,%2)
 
 
-stock GetClosestPlayerToVehicle(vehicleid, ignoredid = INVALID_PLAYER_ID, bool:ignoreVW = false
 #if defined GetVehicleInterior
-	, bool:ignoreInterior = false
+	stock GetClosestPlayerToVehicle(vehicleid, ignoredid = INVALID_PLAYER_ID, bool:ignoreVW = false, bool:ignoreInterior = false) {
+#else
+	stock GetClosestPlayerToVehicle(vehicleid, ignoredid = INVALID_PLAYER_ID, bool:ignoreVW = false) {
 #endif
-) {
-    new Float:x, Float:y, Float:z;
+		new Float:x, Float:y, Float:z;
 
-    if (!GetVehiclePos(vehicleid, x, y, z)) {
-		return INVALID_PLAYER_ID;
-    }
+		if (!GetVehiclePos(vehicleid, x, y, z)) {
+			return INVALID_PLAYER_ID;
+		}
 
-    new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
+		new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
 #if defined GetVehicleInterior
-	if (ignoreInterior)
+		if (ignoreInterior)
 #endif
-	{
-		if (ignoreVW)
 		{
-			new vw = GetVehicleVirtualWorld(vehicleid);
-			foreach (new i : Player) {
-				if (i == ignoredid || vw != GetPlayerVirtualWorld(i)) {
-					continue;
-				}
+			if (ignoreVW)
+			{
+				new vw = GetVehicleVirtualWorld(vehicleid);
+				foreach (new i : Player) {
+					if (i == ignoredid || vw != GetPlayerVirtualWorld(i)) {
+						continue;
+					}
 
-				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
+					if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+			else
+			{
+				foreach (new i : Player) {
+					if (i == ignoredid) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
 				}
 			}
 		}
+#if defined GetVehicleInterior
 		else
 		{
-			foreach (new i : Player) {
-				if (i == ignoredid) {
-					continue;
-				}
+			if (ignoreVW)
+			{
+				new interior = GetVehicleInterior(vehicleid);
+				foreach (new i : Player) {
+					if (i == ignoredid || interior != GetPlayerInterior(i)) {
+						continue;
+					}
 
-				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
+					if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
+				}
+			}
+			else
+			{
+				new vw = GetVehicleVirtualWorld(vehicleid);
+				new interior = GetVehicleInterior(vehicleid);
+				foreach (new i : Player) {
+					if (i == ignoredid || vw != GetPlayerVirtualWorld(i) || interior != GetPlayerInterior(i)) {
+						continue;
+					}
+
+					if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
+						distance = distance2;
+						closestid = i;
+					}
 				}
 			}
 		}
-	}
-#if defined GetVehicleInterior
-	else
-	{
-		if (ignoreVW)
-		{
-			new interior = GetVehicleInterior(vehicleid);
-			foreach (new i : Player) {
-				if (i == ignoredid || interior != GetPlayerInterior(i)) {
-					continue;
-				}
-
-				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
-		else
-		{
-			new vw = GetVehicleVirtualWorld(vehicleid);
-			new interior = GetVehicleInterior(vehicleid);
-			foreach (new i : Player) {
-				if (i == ignoredid || vw != GetPlayerVirtualWorld(i) || interior != GetPlayerInterior(i)) {
-					continue;
-				}
-
-				if ((distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
-					distance = distance2;
-					closestid = i;
-				}
-			}
-		}
-	}
 #endif
 
-    return closestid;
-}
+		return closestid;
+	}
 

--- a/distance.inc
+++ b/distance.inc
@@ -66,7 +66,7 @@ stock Float:dist_GetPlayerDistanceFromPoint(playerid, Float:x, Float:y, Float:z)
 #else
     #define _ALS_GetPlayerDistanceFromPoint
 #endif
-#define GetPlayerDistanceFromPoint dist_GetPlayerDistanceFromPoint
+#define GetPlayerDistanceFromPoint( dist_GetPlayerDistanceFromPoint(
 
 
 stock Float:GetPlayerDistanceFromPoint2D(playerid, Float:x, Float:y) {
@@ -108,7 +108,7 @@ stock Float:dist_GetVehicleDistFromPoint(vehicleid, Float:x, Float:y, Float:z) {
 #else
     #define _ALS_GetVehicleDistFromPoint
 #endif
-#define GetVehicleDistanceFromPoint dist_GetVehicleDistFromPoint
+#define GetVehicleDistanceFromPoint( dist_GetVehicleDistFromPoint(
 
 
 stock bool:IsVehicleInRangeOfPoint(vehicleid, Float:range, Float:x, Float:y, Float:z) {

--- a/distance.inc
+++ b/distance.inc
@@ -65,6 +65,7 @@ stock Float:dist_GetPlayerDistanceFromPoint(playerid, Float:x, Float:y, Float:z)
     #undef GetPlayerDistanceFromPoint
 #else
     #define _ALS_GetPlayerDistanceFromPoint
+	native BAD_GetPlayerDistanceFromPoint(playerid, Float:x, Float:y, Float:z) = GetPlayerDistanceFromPoint;
 #endif
 #define GetPlayerDistanceFromPoint( dist_GetPlayerDistanceFromPoint(
 
@@ -107,6 +108,7 @@ stock Float:dist_GetVehicleDistFromPoint(vehicleid, Float:x, Float:y, Float:z) {
     #undef GetVehicleDistanceFromPoint
 #else
     #define _ALS_GetVehicleDistFromPoint
+	native BAD_GetVehicleDistanceFromPoint(vehicleid, Float:x, Float:y, Float:z) = GetVehicleDistanceFromPoint;
 #endif
 #define GetVehicleDistanceFromPoint( dist_GetVehicleDistFromPoint(
 

--- a/distance.inc
+++ b/distance.inc
@@ -54,11 +54,11 @@ o888o        o888o `Y888""8o     .8'     `Y8bod8P' d888b            o888o       
 */
 
 stock Float:dist_GetPlayerDistanceFromPoint(playerid, Float:x, Float:y, Float:z) {
-    if (!IsPlayerConnected(playerid)) {
-        return FLOAT_INFINITY;
+    if (IsPlayerConnected(playerid)) {
+		return GetPlayerDistanceFromPoint(playerid, x, y, z);
     }
 
-    return GetPlayerDistanceFromPoint(playerid, x, y, z);
+	return FLOAT_INFINITY;
 }
 
 #if defined _ALS_GetPlayerDistanceFromPoint
@@ -73,11 +73,11 @@ stock Float:dist_GetPlayerDistanceFromPoint(playerid, Float:x, Float:y, Float:z)
 stock Float:GetPlayerDistanceFromPoint2D(playerid, Float:x, Float:y) {
     new Float:x2, Float:y2, Float:z2;
 
-    if (!GetPlayerPos(playerid, x2, y2, z2)) {
-        return FLOAT_INFINITY;
+    if (GetPlayerPos(playerid, x2, y2, z2)) {
+		return GetDistanceBetweenPoints2D(x, y, x2, y2);
     }
 
-    return GetDistanceBetweenPoints2D(x, y, x2, y2);
+	return FLOAT_INFINITY;
 }
 
 
@@ -97,11 +97,11 @@ oooooo     oooo           oooo         o8o            oooo                    oo
 */
 
 stock Float:dist_GetVehicleDistFromPoint(vehicleid, Float:x, Float:y, Float:z) {
-    if (!Iter_Contains(Vehicle, vehicleid)) {
-        return FLOAT_INFINITY;
+    if (Iter_Contains(Vehicle, vehicleid)) {
+		return GetVehicleDistanceFromPoint(vehicleid, x, y, z);
     }
 
-    return GetVehicleDistanceFromPoint(vehicleid, x, y, z);
+	return FLOAT_INFINITY;
 }
 
 #if defined _ALS_GetVehicleDistFromPoint
@@ -121,11 +121,11 @@ stock bool:IsVehicleInRangeOfPoint(vehicleid, Float:range, Float:x, Float:y, Flo
 stock Float:GetVehicleDistanceFromPoint2D(vehicleid, Float:x, Float:y) {
     new Float:x2, Float:y2, Float:z2;
 
-    if (!GetVehiclePos(vehicleid, x2, y2, z2)) {
-        return FLOAT_INFINITY;
+    if (GetVehiclePos(vehicleid, x2, y2, z2)) {
+		return GetDistanceBetweenPoints2D(x, y, x2, y2);
     }
 
-    return GetDistanceBetweenPoints2D(x, y, x2, y2);
+	return FLOAT_INFINITY;
 }
 
 
@@ -149,11 +149,11 @@ o888o        o888o `Y888""8o     .8'     `Y8bod8P' d888b            o888o       
 stock Float:GetDistanceBetweenPlayers(playerid1, playerid2) {
     new Float:x, Float:y, Float:z;
 
-    if (!GetPlayerPos(playerid2, x, y, z)) {
-        return FLOAT_INFINITY;
+    if (GetPlayerPos(playerid2, x, y, z)) {
+		return GetPlayerDistanceFromPoint(playerid1, x, y, z);
     }
 
-    return GetPlayerDistanceFromPoint(playerid1, x, y, z);
+	return FLOAT_INFINITY;
 }
 
 
@@ -195,11 +195,11 @@ o888o        o888o `Y888""8o     .8'     `Y8bod8P' d888b                  `8'   
 stock Float:GetPlayerDistanceFromVehicle(playerid, vehicleid) {
     new Float:x, Float:y, Float:z;
 
-    if (!GetVehiclePos(vehicleid, x, y, z)) {
-        return FLOAT_INFINITY;
+    if (GetVehiclePos(vehicleid, x, y, z)) {
+		return GetPlayerDistanceFromPoint(playerid, x, y, z);
     }
 
-    return GetPlayerDistanceFromPoint(playerid, x, y, z);
+	return FLOAT_INFINITY;
 }
 
 
@@ -239,11 +239,11 @@ oooooo     oooo           oooo         o8o            oooo                    oo
 stock Float:GetDistanceBetweenVehicles(vehicleid1, vehicleid2) {
     new Float:x, Float:y, Float:z;
 
-    if (!GetVehiclePos(vehicleid2, x, y, z)) {
-        return FLOAT_INFINITY;
+    if (GetVehiclePos(vehicleid2, x, y, z)) {
+		return GetVehicleDistanceFromPoint(vehicleid1, x, y, z);
     }
 
-    return GetVehicleDistanceFromPoint(vehicleid1, x, y, z);
+	return FLOAT_INFINITY;
 }
 
 

--- a/distance.inc
+++ b/distance.inc
@@ -177,10 +177,8 @@ stock GetClosestPlayerToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ig
     }
 
     new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
-	if (ignoreInterior)
-	{
-		if (ignoreVW)
-		{
+	if (ignoreInterior) {
+		if (ignoreVW) {
 			foreach (new i : Player) {
 				if (i == ignoredid) {
 					continue;
@@ -191,9 +189,7 @@ stock GetClosestPlayerToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ig
 					closestid = i;
 				}
 			}
-		}
-		else
-		{
+		} else {
 			new vw = GetPlayerVirtualWorld(playerid);
 			foreach (new i : Player) {
 				if (i == ignoredid || vw != GetPlayerVirtualWorld(i)) {
@@ -206,11 +202,8 @@ stock GetClosestPlayerToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ig
 				}
 			}
 		}
-	}
-	else
-	{
-		if (ignoreVW)
-		{
+	} else {
+		if (ignoreVW) {
 			new interior = GetPlayerInterior(playerid);
 			foreach (new i : Player) {
 				if (i == ignoredid || interior != GetPlayerInterior(i)) {
@@ -223,8 +216,7 @@ stock GetClosestPlayerToPlayer(playerid, ignoredid = INVALID_VEHICLE_ID, bool:ig
 				}
 			}
 		}
-		else
-		{
+		else {
 			new vw = GetPlayerVirtualWorld(playerid);
 			new interior = GetPlayerInterior(playerid);
 			foreach (new i : Player) {
@@ -304,11 +296,9 @@ stock Float:GetPlayerDistanceFromVehicle(playerid, vehicleid) {
 
 		new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
 #if defined GetVehicleInterior
-		if (ignoreInterior)
+		if (ignoreInterior) {
 #endif
-		{
-			if (ignoreVW)
-			{
+			if (ignoreVW) {
 				foreach (new i : Vehicle) {
 					if (i == ignoredid) {
 						continue;
@@ -319,9 +309,7 @@ stock Float:GetPlayerDistanceFromVehicle(playerid, vehicleid) {
 						closestid = i;
 					}
 				}
-			}
-			else
-			{
+			} else {
 				new vw = GetPlayerVirtualWorld(playerid);
 				foreach (new i : Vehicle) {
 					if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
@@ -334,12 +322,9 @@ stock Float:GetPlayerDistanceFromVehicle(playerid, vehicleid) {
 					}
 				}
 			}
-		}
 #if defined GetVehicleInterior
-		else
-		{
-			if (ignoreVW)
-			{
+		} else {
+			if (ignoreVW) {
 				new interior = GetPlayerInterior(playerid);
 				foreach (new i : Vehicle) {
 					if (i == ignoredid || interior != GetVehicleInterior(i)) {
@@ -351,9 +336,7 @@ stock Float:GetPlayerDistanceFromVehicle(playerid, vehicleid) {
 						closestid = i;
 					}
 				}
-			}
-			else
-			{
+			} else {
 				new vw = GetPlayerVirtualWorld(playerid);
 				new interior = GetPlayerInterior(playerid);
 				foreach (new i : Vehicle) {
@@ -432,11 +415,9 @@ stock Float:GetDistanceBetweenVehicles(vehicleid1, vehicleid2) {
 
 		new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
 #if defined GetVehicleInterior
-		if (ignoreInterior)
+		if (ignoreInterior) {
 #endif
-		{
-			if (ignoreVW)
-			{
+			if (ignoreVW) {
 				foreach (new i : Vehicle) {
 					if (i == ignoredid) {
 						continue;
@@ -447,9 +428,7 @@ stock Float:GetDistanceBetweenVehicles(vehicleid1, vehicleid2) {
 						closestid = i;
 					}
 				}
-			}
-			else
-			{
+			} else {
 				new vw = GetVehicleVirtualWorld(vehicleid);
 				foreach (new i : Vehicle) {
 					if (i == ignoredid || vw != GetVehicleVirtualWorld(i)) {
@@ -462,12 +441,9 @@ stock Float:GetDistanceBetweenVehicles(vehicleid1, vehicleid2) {
 					}
 				}
 			}
-		}
 #if defined GetVehicleInterior
-		else
-		{
-			if (ignoreVW)
-			{
+		} else {
+			if (ignoreVW) {
 				new interior = GetVehicleInterior(vehicleid);
 				foreach (new i : Vehicle) {
 					if (i == ignoredid || interior != GetVehicleInterior(i)) {
@@ -479,9 +455,7 @@ stock Float:GetDistanceBetweenVehicles(vehicleid1, vehicleid2) {
 						closestid = i;
 					}
 				}
-			}
-			else
-			{
+			} else {
 				new vw = GetVehicleVirtualWorld(vehicleid);
 				new interior = GetVehicleInterior(vehicleid);
 				foreach (new i : Vehicle) {
@@ -535,11 +509,9 @@ oooooo     oooo           oooo         o8o            oooo                    oo
 
 		new Float:distance = FLOAT_INFINITY, closestid = INVALID_PLAYER_ID, Float:distance2;
 #if defined GetVehicleInterior
-		if (ignoreInterior)
+		if (ignoreInterior) {
 #endif
-		{
-			if (ignoreVW)
-			{
+			if (ignoreVW) {
 				new vw = GetVehicleVirtualWorld(vehicleid);
 				foreach (new i : Player) {
 					if (i == ignoredid || vw != GetPlayerVirtualWorld(i)) {
@@ -551,9 +523,7 @@ oooooo     oooo           oooo         o8o            oooo                    oo
 						closestid = i;
 					}
 				}
-			}
-			else
-			{
+			} else {
 				foreach (new i : Player) {
 					if (i == ignoredid) {
 						continue;
@@ -565,12 +535,9 @@ oooooo     oooo           oooo         o8o            oooo                    oo
 					}
 				}
 			}
-		}
 #if defined GetVehicleInterior
-		else
-		{
-			if (ignoreVW)
-			{
+		} else {
+			if (ignoreVW) {
 				new interior = GetVehicleInterior(vehicleid);
 				foreach (new i : Player) {
 					if (i == ignoredid || interior != GetPlayerInterior(i)) {
@@ -582,9 +549,7 @@ oooooo     oooo           oooo         o8o            oooo                    oo
 						closestid = i;
 					}
 				}
-			}
-			else
-			{
+			} else {
 				new vw = GetVehicleVirtualWorld(vehicleid);
 				new interior = GetVehicleInterior(vehicleid);
 				foreach (new i : Player) {


### PR DESCRIPTION
Also inlined a few calls and made native redefinitions work better with the ALS hooks.

The inner loops of the find closest functions would have been simpler with:

```pawn
				new vw = GetVehicleVirtualWorld(vehicleid);
				new interior = GetVehicleInterior(vehicleid);
				foreach (new i : Player) {
					if (i != ignoredid
					&& (ignoreVW || vw == GetPlayerVirtualWorld(i))
					&& (ignoreInterior || interior == GetPlayerInterior(i))
					&& (distance2 = BAD_GetPlayerDistanceFromPoint(i, x, y, z)) < distance) {
						distance = distance2;
						closestid = i;
					}
				}
```

But that's a lot more code to run every loop, so I moved constant checks outside the main loop.  That's why chunks of the functions are repeated four times each.